### PR TITLE
potential fix for GravityChangeWrapper

### DIFF
--- a/adrl/continual_learning.py
+++ b/adrl/continual_learning.py
@@ -7,6 +7,7 @@ class GravityChangeWrapper(Wrapper):
     def __init__(self, env):
         super().__init__(env)
         self.n_steps = 0
+        self.n_total_steps = 0
         self.n_switches = 0
 
     def step(self, action):
@@ -16,10 +17,15 @@ class GravityChangeWrapper(Wrapper):
             truncated = True
         return state, reward, terminated, truncated, info
 
-    def reset(self):
-        self.env.reset()
-        if self.n_steps // 10000 <= self.n_switches:
-            change_kind = np.random.choice(["flip", "random"])
+def reset(self):
+        self.n_total_steps += self.n_steps
+        self.n_steps = 0
+        
+        if self.n_total_steps  // 10000 > self.n_switches:
+            # as gravity has to be in (-20. 0.01) flipping does not make sense
+            # change_kind = np.random.choice(["flip", "random"])
+            change_kind = "random"  
+            
             if change_kind == "flip":
                 gravity = -self.env.context["GRAVITY_Y"]
             else:


### PR DESCRIPTION
## Slide fix PR

Thanks for improving the slides! Here are some questions as info for us and sanity checks for you before submitting the PR:

### What kind of fix are you pushing?
<other_please_describe\>
I think the current `GravityChangeWrapper` implementation does not work as intended (at least to my understanding).
Previously, it changed the gravity in each reset call. Also, flipping the gravity does not result in any changes in the environment since gravity has to be in (-20, 0.01). Apparently, the environment flips it back to the negative value if gravity is greater than zero.

### In case of a clarity fix, why do you prefer your option?
It implements the behaviour that was discussed during the lecture.

### In case of a factual error, did you include a source or correct the source?
<n\>

If everything looks fine to you, please assign @TheEimer as as reviewer for this PR.